### PR TITLE
Fix child handle pointer

### DIFF
--- a/winpty.go
+++ b/winpty.go
@@ -152,3 +152,7 @@ func (obj *WinPTY) Close() {
 
 	obj.closed = true
 }
+
+func (obj *WinPTY) GetProcHandle() uintptr {
+	return obj.childHandle
+}

--- a/winpty.go
+++ b/winpty.go
@@ -119,7 +119,7 @@ func OpenWithOptions(options Options) (*WinPTY, error) {
 		spawnErr  uintptr
 		lastError *uint32
 	)
-	spawnRet, _, _ := winpty_spawn.Call(wp, spawnCfg, uintptr(unsafe.Pointer(obj.childHandle)), uintptr(0), uintptr(unsafe.Pointer(lastError)), uintptr(unsafe.Pointer(spawnErr)))
+	spawnRet, _, _ := winpty_spawn.Call(wp, spawnCfg, uintptr(unsafe.Pointer(&obj.childHandle)), uintptr(0), uintptr(unsafe.Pointer(lastError)), uintptr(unsafe.Pointer(spawnErr)))
 	winpty_spawn_config_free.Call(spawnCfg)
 	defer winpty_error_free.Call(spawnErr)
 


### PR DESCRIPTION
Thanks for the great work.

This fixes a bug were `childHandle` was returning invalid handles (always 0)

`childHandle` was not being properly used to capture as a pointer. Also exposes the child handle with a method.