### PR TITLE
Dont panic if dll not available

### DIFF
--- a/winpty_386.go
+++ b/winpty_386.go
@@ -8,6 +8,12 @@ import (
 
 func createAgentCfg(flags uint32) (uintptr, error) {
 	var errorPtr uintptr
+
+	err := winpty_error_free.Find() // check if dll available
+	if err != nil {
+		return uintptr(0), err
+	}
+
 	defer winpty_error_free.Call(errorPtr)
 
 	agentCfg, _, _ := winpty_config_new.Call(

--- a/winpty_amd64.go
+++ b/winpty_amd64.go
@@ -8,6 +8,12 @@ import (
 
 func createAgentCfg(flags uint32) (uintptr, error) {
 	var errorPtr uintptr
+
+	err := winpty_error_free.Find() // check if dll available
+	if err != nil {
+		return uintptr(0), err
+	}
+
 	defer winpty_error_free.Call(errorPtr)
 
 	agentCfg, _, _ := winpty_config_new.Call(uintptr(flags), uintptr(unsafe.Pointer(errorPtr)))


### PR DESCRIPTION
Instead of panic we return error "Failed to load winpty.dll: The specified module could not be found."

Possible check for this error to provide fallback behavior:

```go
pty, err := winpty.OpenDefault("", cmd)

if err != nil {
        if err.Error() == "Failed to load winpty.dll: The specified module could not be found." {
	        log.Printf("winpty not found, falling back to std passthrough")
        } else {
	        return err
        }
}
```